### PR TITLE
Since proposal 287 GHC is fussier about `forall`

### DIFF
--- a/src/Data/GADT/Internal.hs
+++ b/src/Data/GADT/Internal.hs
@@ -81,7 +81,7 @@ instance (GShow a, GShow b) => GShow (Product a b) where
 -- in turn equivalent to @ReadS (Exists t)@ (with @data Exists t where Exists :: t a -> Exists t@)
 type GReadS t = String -> [(Some t, String)]
 
-getGReadResult :: Some tag -> (forall a. tag a -> b) -> b
+getGReadResult :: Some tag -> forall b. (forall a. tag a -> b) -> b
 getGReadResult = withSome
 
 mkGReadResult :: tag a -> Some tag


### PR DESCRIPTION
See:

    https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst

The type of `getGReadResult` no longer matches the type of `withSome` in GHC-head.