### PR TITLE
doesn't need semigroups

### DIFF
--- a/some.cabal
+++ b/some.cabal
@@ -82,8 +82,7 @@ library
 
   if !impl(ghc >=8.0)
     build-depends:
-        semigroups           >=0.18.5 && <0.20
-      , transformers         >=0.3    && <0.6
+        transformers         >=0.3    && <0.6
       , transformers-compat  >=0.6    && <0.7
 
   if impl(ghc >=9.0)


### PR DESCRIPTION
I removed the dependency on semigroups since it's not used anywhere