### PR TITLE
Add instances for `SNat`, `SSymbol`, and `SChar`

### DIFF
--- a/some.cabal
+++ b/some.cabal
@@ -72,6 +72,10 @@ library
       base     >=4.12    && <4.20
     , deepseq  >=1.4.4.0 && <1.6
 
+  if !impl(ghc >= 9.8)
+    build-depends:
+      base-orphans >= 0.9.1 && <0.10
+
   if impl(ghc >=9.0)
     -- these flags may abort compilation with GHC-8.10
     -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295

--- a/src/Data/EqP.hs
+++ b/src/Data/EqP.hs
@@ -20,6 +20,12 @@ import System.Mem.StableName (StableName, eqStableName)
 #if MIN_VERSION_base(4,18,0)
 import Data.Functor.Product (Product (..))
 import Data.Functor.Sum (Sum (..))
+import qualified GHC.TypeLits as TL
+import qualified GHC.TypeNats as TN
+#endif
+
+#if !MIN_VERSION_base(4,19,0)
+import Data.Orphans ()
 #endif
 
 import qualified Type.Reflection as TR
@@ -87,6 +93,17 @@ instance (EqP a, EqP b) => EqP (a :*: b) where
 
 instance EqP TR.TypeRep where
     eqp x y = TR.SomeTypeRep x == TR.SomeTypeRep y
+
+#if MIN_VERSION_base(4,18,0)
+instance EqP TL.SChar where
+    eqp x y = TL.fromSChar x == TL.fromSChar y
+
+instance EqP TL.SSymbol where
+    eqp x y = TL.fromSSymbol x == TL.fromSSymbol y
+
+instance EqP TN.SNat where
+    eqp x y = TN.fromSNat x == TN.fromSNat y
+#endif
 
 instance EqP Proxy where
     eqp _ _ = True

--- a/src/Data/OrdP.hs
+++ b/src/Data/OrdP.hs
@@ -20,6 +20,12 @@ import GHC.Generics         ((:*:) (..), (:+:) (..))
 #if MIN_VERSION_base(4,18,0)
 import Data.Functor.Product (Product (..))
 import Data.Functor.Sum (Sum (..))
+import qualified GHC.TypeLits as TL
+import qualified GHC.TypeNats as TN
+#endif
+
+#if !MIN_VERSION_base(4,19,0)
+import Data.Orphans ()
 #endif
 
 import qualified Type.Reflection as TR
@@ -74,6 +80,17 @@ instance (OrdP a, OrdP b) => OrdP (a :*: b) where
 
 instance OrdP TR.TypeRep where
     comparep x y = compare (TR.SomeTypeRep x) (TR.SomeTypeRep y)
+
+#if MIN_VERSION_base(4,18,0)
+instance OrdP TL.SChar where
+    comparep x y = compare (TL.fromSChar x) (TL.fromSChar y)
+
+instance OrdP TL.SSymbol where
+    comparep x y = compare (TL.fromSSymbol x) (TL.fromSSymbol y)
+
+instance OrdP TN.SNat where
+    comparep x y = compare (TN.fromSNat x) (TN.fromSNat y)
+#endif
 
 instance OrdP Proxy where
     comparep _ _ = EQ


### PR DESCRIPTION
These were introduced to `GHC.TypeNats` and `GHC.TypeLits` in `base-4.18.0.0`. They did not receive `Eq` or `Ord` instances until `base-4.19.0.0`, however, which are required for the superclasses of `EqP` and `OrdP`. To account for this, I introduce a conditional dependency on `base-orphans`, which backports the `Eq` and `Ord` instances to older versions of `base`.